### PR TITLE
Add support for specifying a RabbitMQ routing key for an event.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.6.0
+-----
+
+* ``RabbitMQPublisher`` will look for a `routing_key` context parameter on
+  an event, and will use that value as the routing key for the event.
+
 0.5.0
 -----
 

--- a/yg/emanate/observers.py
+++ b/yg/emanate/observers.py
@@ -112,9 +112,10 @@ class RabbitMQPublisher(QueuePublisher):
         properties = Properties()
         if event.context:
             properties.headers = event.context
+        routing_key = properties.headers.pop('routing_key', '')
 
         try:
-            self.publisher.publish(self.exchange, '', event.data, properties)
+            self.publisher.publish(self.exchange, routing_key, event.data, properties)
         except (AMQPError, RecursionError) as exc:
             log.exception('Cannot publish to RabbitMQ: %r', exc)
             log.warn('Failed to publish message payload %s with context %s',

--- a/yg/emanate/observers.py
+++ b/yg/emanate/observers.py
@@ -112,7 +112,7 @@ class RabbitMQPublisher(QueuePublisher):
         properties = Properties()
         if event.context:
             properties.headers = event.context
-        routing_key = properties.headers.pop('routing_key', '')
+        routing_key = properties.headers.get('routing_key', '')
 
         try:
             self.publisher.publish(self.exchange, routing_key, event.data, properties)


### PR DESCRIPTION
This is done by providing a `routing_key` context parameter on the event.